### PR TITLE
Include expected best practices in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Take a look at the open issues on the repository to see how you can contribute. 
 
 The language of the project is English to make it more accesible worldwide.
 
+Please stick to the following best practices when contributing to this project:
+- Open a new branch and a pull request (PR) whenever you want to change the code or documentation
+- Make sure to provide enough details about the changes in your PR so other contributors can easily understand them  
+- Always wait for at least one approving review before merging the PR
+
 Currently, the code is functional, but the documentation needs work, which makes it hard for communities to build their own version. The work plan is on the short medium term is:
 1. gather ideas and contributions for an Alpha release
 2. incorporate pull requests, contributions which are a short term priority


### PR DESCRIPTION
This PR adds the expected best practices from contributors to the project to the README.

@soyrandom1 suggested we implement these practices to ensure sustainable and quality work going forward. He already created labels for issues to better organize the work we have to do.

I also changed the repo setting to make `main` a protected branch requiring PRs to have at least 1 approving review before merging. @soyrandom1 could you please check if the settings on the repo are correct for this? I'm a bit new to managing repos with multiple contributors. I propose we require 1 approving review instead of 2 because of the project size and because most developers that are a member of the `abracm` organisation on GitHub probably won't be active on this project for now.